### PR TITLE
Adicionados algoritmos de inferência em python (MLP e k-NN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .python-version
 poetry.lock
+Algoritmos\ python/Dados/

--- a/Algoritmos python/download.py
+++ b/Algoritmos python/download.py
@@ -1,0 +1,9 @@
+import os
+
+import requests
+
+response = requests.get(
+    'https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data'
+)
+with open(os.path.join('Dados', 'iris.csv'), mode='wb') as f:
+    f.write(response.content)

--- a/Algoritmos python/download.py
+++ b/Algoritmos python/download.py
@@ -5,5 +5,8 @@ import requests
 response = requests.get(
     'https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data'
 )
+
+if not os.path.exists('Dados'):
+    os.mkdir('Dados')
 with open(os.path.join('Dados', 'iris.csv'), mode='wb') as f:
     f.write(response.content)

--- a/Algoritmos python/k-nn.py
+++ b/Algoritmos python/k-nn.py
@@ -1,0 +1,64 @@
+import os
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+
+def calcula_distancias(u: np.ndarray, v: np.ndarray) -> np.ndarray:
+    assert isinstance(
+        v, np.ndarray
+    ), f'V deve ser um array numpy, e não {type(v)}'
+    assert isinstance(
+        u, np.ndarray
+    ), f'U deve ser um array numpy, e não {type(u)}'
+    assert (
+        u.shape[1] == v.shape[0]
+    ), f'U deve ter dimensão {v.shape} e não {u.shape}'
+    return np.apply_along_axis(np.linalg.norm, 1, u - v)
+
+
+def knn(k: int, X_treino: np.ndarray, y_treino: np.ndarray):
+    def dentro(teste: np.ndarray) -> list:
+        distancias = calcula_distancias(X_treino, teste)
+        idx_menores = distancias.argsort()[:k]
+        resultados_treino = y_treino[idx_menores]
+        resultados_teste = [0, 0, 0]
+        idx_teste = resultados_treino.sum(axis=0).argsort()[-1]
+        resultados_teste[idx_teste] = 1
+        return resultados_teste
+
+    return dentro
+
+
+dados = np.loadtxt(
+    os.path.join('Dados', 'iris.csv'), delimiter=',', usecols=[0, 1, 2, 3]
+)
+
+# Ajusta dados de teste
+y = pd.read_csv(
+    os.path.join('Dados', 'iris.csv'),
+    sep=',',
+    usecols=[4],
+    header=None,
+    names=['Nome'],
+)
+y.loc[:, 'setosa'] = 0
+y.loc[:, 'virginica'] = 0
+y.loc[:, 'versicolor'] = 0
+y.loc[y['Nome'] == 'Iris-setosa', 'setosa'] = 1
+y.loc[y['Nome'] == 'Iris-virginica', 'virginica'] = 1
+y.loc[y['Nome'] == 'Iris-versicolor', 'versicolor'] = 1
+del y['Nome']
+y = np.array(y)
+
+# Separa conjunto de treino e teste e calcula resultados
+X_treino, X_teste, y_treino, y_teste = train_test_split(
+    dados, y, test_size=0.33, random_state=42
+)
+inferencia = knn(11, X_treino, y_treino)
+resultado = np.apply_along_axis(inferencia, 1, X_teste)
+
+# Encontra o erro
+erro = resultado - y_teste
+print(erro)

--- a/Algoritmos python/k-nn.py
+++ b/Algoritmos python/k-nn.py
@@ -1,11 +1,13 @@
 import os
+from typing import Callable
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
 
-def calcula_distancias(u: np.ndarray, v: np.ndarray) -> np.ndarray:
+def calcula_distancias(u: npt.ArrayLike, v: npt.ArrayLike) -> npt.ArrayLike:
     assert isinstance(
         v, np.ndarray
     ), f'V deve ser um array numpy, e não {type(v)}'
@@ -18,7 +20,7 @@ def calcula_distancias(u: np.ndarray, v: np.ndarray) -> np.ndarray:
     return np.apply_along_axis(np.linalg.norm, 1, u - v)
 
 
-def knn(k: int, X_treino: np.ndarray, y_treino: np.ndarray):
+def knn(k: int, X_treino: npt.ArrayLike, y_treino: npt.ArrayLike) -> Callable:
     def dentro(teste: np.ndarray) -> list:
         distancias = calcula_distancias(X_treino, teste)
         idx_menores = distancias.argsort()[:k]

--- a/Algoritmos python/mlp.py
+++ b/Algoritmos python/mlp.py
@@ -1,0 +1,64 @@
+from typing import Callable
+
+import numpy as np
+import numpy.typing as npt
+
+
+class Ativacoes:
+    def __init__(self):
+        return
+
+    def sigmoide(self, x):
+        return 1 / (1 + np.exp(x))
+
+    def relu(self, x):
+        if x.shape == 1:
+            return x if x > 0 else 0
+        resultados = []
+        for valor in x:
+            resultados.append(valor if valor > 0 else 0)
+        return resultados
+
+    def tanh(self, x):
+        exp = np.exp(2 * x)
+        return (exp - 1) / (exp + 1)
+
+
+class Neuronio:
+    def __init__(self, pesos: npt.ArrayLike, vies: npt.DTypeLike):
+        self.pesos = pesos
+        self.entradas = len(pesos)
+        self.vies = vies
+
+    def __len__(self):
+        return self.entradas
+
+    def __str__(self):
+        return f"""Neurônio com {self.entradas} entradas"""
+
+    def processa(
+        self, entradas: npt.ArrayLike, ativacao: Callable
+    ) -> npt.ArrayLike:
+        entradas = np.array(entradas)
+        assert entradas.T.shape[0] == len(
+            self
+        ), f'O número de entradas deve ser o mesmo que o número de pesos, mas são, respectivamente, {entradas.shape[1]} e {len(self)}'
+        produto = self.pesos @ entradas.T + self.vies
+
+        return ativacao(produto)
+
+
+ativ = Ativacoes()
+n_entradas = 4
+n_amostras = 5
+neuronio = Neuronio(np.random.randn(n_entradas), np.random.randn(1))
+entradas = np.random.randn(n_amostras, n_entradas)
+resultado_tanh = neuronio.processa(entradas, ativ.tanh)
+resultado_relu = neuronio.processa(entradas, ativ.relu)
+resultado_sigmoide = neuronio.processa(entradas, ativ.sigmoide)
+print('Resultado para função de ativação tanh:')
+print(resultado_tanh)
+print('\nResultado para função de ativação relu:')
+print(resultado_relu)
+print('\nResultado para função de ativação sigmoide:')
+print(resultado_sigmoide)

--- a/Algoritmos python/mlp.py
+++ b/Algoritmos python/mlp.py
@@ -12,7 +12,7 @@ class Ativacoes:
         return 1 / (1 + np.exp(x))
 
     def relu(self, x):
-        if x.shape == 1:
+        if x.ndim == 0:
             return x if x > 0 else 0
         resultados = []
         for valor in x:
@@ -25,7 +25,11 @@ class Ativacoes:
 
 
 class Neuronio:
-    def __init__(self, pesos: npt.ArrayLike, vies: npt.DTypeLike):
+    def __init__(self, pesos: npt.ArrayLike, vies: npt.DTypeLike = 0):
+        pesos = np.array(pesos)
+        assert (
+            pesos.ndim == 1
+        ), f'O vetor de pesos deve ter apenas uma dimensão, porém ela possuí {pesos.ndim}'
         self.pesos = pesos
         self.entradas = len(pesos)
         self.vies = vies
@@ -34,7 +38,7 @@ class Neuronio:
         return self.entradas
 
     def __str__(self):
-        return f"""Neurônio com {self.entradas} entradas"""
+        return f'Neurônio com {self.entradas} entradas'
 
     def processa(
         self, entradas: npt.ArrayLike, ativacao: Callable
@@ -48,17 +52,96 @@ class Neuronio:
         return ativacao(produto)
 
 
-ativ = Ativacoes()
-n_entradas = 4
-n_amostras = 5
-neuronio = Neuronio(np.random.randn(n_entradas), np.random.randn(1))
-entradas = np.random.randn(n_amostras, n_entradas)
-resultado_tanh = neuronio.processa(entradas, ativ.tanh)
-resultado_relu = neuronio.processa(entradas, ativ.relu)
-resultado_sigmoide = neuronio.processa(entradas, ativ.sigmoide)
-print('Resultado para função de ativação tanh:')
-print(resultado_tanh)
-print('\nResultado para função de ativação relu:')
-print(resultado_relu)
-print('\nResultado para função de ativação sigmoide:')
-print(resultado_sigmoide)
+class Camada:
+    def __init__(
+        self, neuronios: list, ativacao: Callable = Ativacoes().sigmoide
+    ):
+        for neuronio in neuronios[1:]:
+            assert (
+                neuronios[0].entradas == neuronio.entradas
+            ), f'O número de entradas de todos os neurônios de uma mesma camada deve ser igual, mas os neurônios escolhidos têm {[neuronio.entradas for neuronio in neuronios]}'
+        self.neuronios = neuronios
+        self.tamanho = len(neuronios)
+        self.entradas = self.neuronios[0].entradas
+        self.ativacao = ativacao
+
+    def __len__(self):
+        return self.tamanho
+
+    def __str__(self):
+        return f'Camada contendo {self.tamanho} neurônios de {self.entradas} entradas.'
+
+    def processa(self, entradas: npt.ArrayLike) -> npt.ArrayLike:
+        entradas = np.array(entradas)
+        assert (
+            entradas.ndim <= 2
+        ), f'A matriz de entradas deve ter duas dimensões, porém ela possuí {entradas.ndim}'
+        if entradas.ndim == 1:
+            entradas = np.array([entradas])
+        saida = []
+        for neuronio in self.neuronios:
+            saida.append(neuronio.processa(entradas, self.ativacao))
+        return np.array(saida)
+
+
+class MLP:
+    def __init__(self, camadas: list = []):
+        self.camadas = camadas
+        self.n_camadas = len(self.camadas)
+
+    def __len__(self):
+        return self.n_camadas
+
+    def __str__(self):
+        return f'Rede neural do tipo MLP com {self.n_camadas} camadas, {self.camadas[0].entradas} entradas e {len(self.camadas[-1])} saidas'
+
+    def adiciona_camada(self, camada):
+        self.camadas.append(camada)
+        self.n_camadas += 1
+
+    def processa(self, entradas: npt.ArrayLike) -> npt.ArrayLike:
+        entradas = np.array(entradas)
+        assert (
+            entradas.ndim <= 2
+        ), f'A matriz de entradas deve ter duas dimensões, porém ela possuí {entradas.ndim}'
+        if entradas.ndim == 1:
+            entradas = np.array([entradas])
+        assert (
+            entradas.shape[1] == self.camadas[0].entradas
+        ), f'A matriz de entradas deve ter {self.camadas[0].entradas} colunas, mas possuí {entradas.shape[1]}.'
+        for camada in self.camadas:
+            entradas = camada.processa(entradas).T
+        return entradas
+
+
+camadas = 7
+entradas = 4
+saidas = 2
+tamanhos = [2, 4, 8, 16, 8, 4, 2]
+print(tamanhos)
+
+rede = MLP([Camada([Neuronio(np.random.randn(entradas)) for _ in range(4)])])
+for camada, tamanho in enumerate(tamanhos):
+    rede.adiciona_camada(
+        Camada(
+            [
+                Neuronio(np.random.randn(rede.camadas[-1].tamanho))
+                for _ in range(tamanho)
+            ]
+        )
+    )
+
+rede.adiciona_camada(
+    Camada(
+        [
+            Neuronio(np.random.randn(rede.camadas[-1].tamanho))
+            for i in range(saidas)
+        ]
+    )
+)
+
+for camada in rede.camadas:
+    print(camada)
+
+entradas = np.random.randn(10, entradas)
+print(rede.processa(entradas))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "fpg-i-a"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+packages = [{include = "fpg_i_a"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+numpy = "^1.24.1"
+requests = "^2.28.2"
+scikit-learn = "^1.2.1"
+pandas = "^1.5.3"
+
+[tool.poetry.group.dev.dependencies]
+blue = "^0.9.1"
+isort = "^5.11.4"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Scripts para realização de inferência utilizando k-NN no dataset iris e MLP com pesos e entradas aleatórias finalizados. Futuramente, quando tivermos um script de treino de MLP pronto, adicionarei a possibilidade de utilizar esse código de inferência de MLP para o mesmo dataset utilizado para k-NN, assim será possível comprar os resultados dos dois métodos.